### PR TITLE
Enable TravisCI for CI testing compilation on Linux and MacOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
     script:
     - make
   - name: macOS
-    compiler: clang
+    #compiler: clang
     os: osx
     osx_image: xcode10.2
     before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: cpp
+dist: bionic
+matrix:
+  include:
+  - name: Linux
+    addons:
+      apt_packages:
+      - libsdl2-dev
+    script:
+    - make
+  - name: macOS
+    compiler: clang
+    os: osx
+    osx_image: xcode10.2
+    before_script:
+    - brew install sdl2
+    script:
+    - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ matrix:
     addons:
       apt_packages:
       - libsdl2-dev
+      - libsdl2-mixer-dev
+      - libxmp-dev
     script:
     - make
   - name: macOS
@@ -13,6 +15,6 @@ matrix:
     os: osx
     osx_image: xcode10.2
     before_script:
-    - brew install sdl2
+    - brew install sdl2 sdl2_mixer libxmp
     script:
     - make


### PR DESCRIPTION
This small PR will enable to use TravisCI to make sure the code is still compiling in Linux and MacOS. TravisCI is free, but you need to [enable it](https://docs.travis-ci.com/user/tutorial/#to-get-started-with-travis-ci) in your Github account. Currently, Linux compilation works, but MacOS fails:

```
$ make
g++ -g -fpermissive   -c -o binresource.o binresource.cpp
g++ -g -fpermissive   -c -o config.o config.cpp
g++ -g -fpermissive   -c -o decrunchmania.o decrunchmania.cpp
decrunchmania.cpp:69:15: error: use of undeclared identifier 'nullptr'
        Decrunch(in, nullptr);
                     ^
decrunchmania.cpp:255:11: error: cast from pointer to smaller type 'unsigned short' loses information
    d7 += (unsigned short)a5;
          ^~~~~~~~~~~~~~~~~~
decrunchmania.cpp:302:10: error: cast from pointer to smaller type 'unsigned short' loses information
    d5 = (unsigned short)a3;
         ^~~~~~~~~~~~~~~~~~
3 errors generated.
make: *** [decrunchmania.o] Error 1
The command "make" exited with 2.
```
This should not be difficult to fix, but I don't own a Mac, so it's a pain to fix without testing on a real system.