### PR TITLE
Add Hud and Font destructors

### DIFF
--- a/font.cpp
+++ b/font.cpp
@@ -260,3 +260,18 @@ void Font::PrintMultiLineMessage(std::string message, int y, SDL_Surface* dest)
 	}
 	PrintMessage(message, y, dest, 1);
 }
+
+Font::~Font()
+{
+	for (int i = 0; i < glyphs; i++)
+	{
+		if (surfaces[i])
+		{
+			SDL_FreeSurface(surfaces[i]);
+		}
+		if (surfaces32[i])
+		{
+			SDL_FreeSurface(surfaces32[i]);
+		}
+	}
+}

--- a/font.h
+++ b/font.h
@@ -6,7 +6,8 @@
 class Font
 {
 	public:
-		
+
+	~Font();
 	bool Load(CrmFile& file);
 	bool Load2(CrmFile& file);
 	void SetPal(SDL_Surface* palsurface); 

--- a/hud.cpp
+++ b/hud.cpp
@@ -230,6 +230,15 @@ Hud::Hud()
 	}
 }
 
+Hud::~Hud() {
+	SDL_FreeSurface(healthbar);
+	SDL_FreeSurface(healthbaron);
+	SDL_FreeSurface(weaponbar);
+	for (int i = 0; i < 5; i++) {
+		SDL_FreeSurface(weaponsprites[i]);
+	}
+}
+
 void Hud::Render(SDL_Surface* surface, MapObject& player, Font& font)
 {
 	SDL_Rect dstrect;

--- a/hud.h
+++ b/hud.h
@@ -12,6 +12,7 @@ class Hud
 {
 	public:
 		Hud();
+		~Hud();
 		void Render(SDL_Surface* surface, MapObject& player, Font& font);
 
 		enum MESSAGE


### PR DESCRIPTION
Free allocated surfaces, what fixes memory leaks found with Valgrind.