### PR TITLE
Fix few warnings raised by -Wall option

### DIFF
--- a/config.cpp
+++ b/config.cpp
@@ -353,7 +353,7 @@ namespace Config
 
 							configkeys[i] = std::stoi(val);
 
-							if ((i + 1) << KEY_END)
+							if ((i + 1) < KEY_END)
 							{
 								line = line.substr(line.find(" ") + 1, std::string::npos);
 							}

--- a/gamelogic.cpp
+++ b/gamelogic.cpp
@@ -701,7 +701,7 @@ bool GameLogic::Update(Camera* cam)
 	Quick camrots[4], camrotstrafe[4];
 
 	GloomMaths::GetCamRot(cam->rotquick.GetInt()&0xFF, camrots);
-	GloomMaths::GetCamRot((cam->rotquick.GetInt())+64&0xFF, camrotstrafe);
+	GloomMaths::GetCamRot(((cam->rotquick.GetInt())+64)&0xFF, camrotstrafe);
 	const Uint8 *keystate = SDL_GetKeyboardState(NULL);
 
 	Quick newx = cam->x;

--- a/gloommap.cpp
+++ b/gloommap.cpp
@@ -199,7 +199,7 @@ void Texture::DumpDebug(const char* name)
 	//dump a ppm file
 	FILE* file = fopen(name, "wb");
 
-	fprintf(file, "P6\n64 %i\n255\n", columns.size());
+	fprintf(file, "P6\n64 %lu\n255\n", columns.size());
 
 	for (size_t c = 0; c < columns.size(); c++)
 	{

--- a/monsterlogic.cpp
+++ b/monsterlogic.cpp
@@ -2215,7 +2215,7 @@ void DeathCharge(MapObject& o, GameLogic* logic)
 	DeathBounce(o, logic);
 	DeathAnim(o, logic);
 
-	int32_t ang = logic->PickCalc(o) & 255 - o.data.ms.rotquick.GetInt() & 255;
+	int32_t ang = (logic->PickCalc(o) & 255) - (o.data.ms.rotquick.GetInt() & 255);
 
 	if (ang < 0) ang = -ang;
 
@@ -2278,7 +2278,7 @@ void DeathLogic(MapObject& o, GameLogic* logic)
 
 	if (CheckVecs(o, logic))
 	{
-		int32_t ang = logic->PickCalc(o)&255 - o.data.ms.rotquick.GetInt()&255;
+		int32_t ang = (logic->PickCalc(o)&255) - (o.data.ms.rotquick.GetInt()&255);
 
 		if (ang < 0) ang = -ang;
 		


### PR DESCRIPTION
- config.c: '<<' used instead of '<' in a comparison (-Wint-in-bool-context)
- gloommap.cpp: signed format used instead of unsigned (-Wformat)
- gamelogic.cpp: added suggested parentheses (-Wparentheses)
- monsterlogic.cpp: added suggested parentheses (-Wparentheses)